### PR TITLE
Load Sage interops directly from instalations instead of working with local files

### DIFF
--- a/Sage50c.API.Sample/Sage50c.API.Sample/Program.cs
+++ b/Sage50c.API.Sample/Sage50c.API.Sample/Program.cs
@@ -1,18 +1,77 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Windows.Forms;
 
 namespace Sage50c.API.Sample {
     static class Program {
+
+        #region "Constants"
+
+        // These directores are the default directories where the Sage50c dlls are located.
+        private const string _sageDirInterops = "Program Files (x86)\\Common Files\\sage\\2070\\50c2022\\Interops\\";
+        private const string _sageDirExtraOnline = "Program Files (x86)\\Common Files\\sage\\2070\\50c2022\\Extra Online\\ Files (x86)\\Common Files\\sage\\2070\\50c2022\\Interops\\";
+
+        #endregion
+
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
         static void Main(){
+
+            ListOfDirectories.Add($@"{BaseDirectoryRoot}{_sageDirInterops}");
+            ListOfDirectories.Add($@"{BaseDirectoryRoot}{_sageDirExtraOnline}");
+
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new fApi());
         }
+
+        #region "AssemblyResolve"
+
+        private static string BaseDirectoryRoot { get; set; } = Path.GetPathRoot(AppDomain.CurrentDomain.BaseDirectory);
+        private static List<string> ListOfDirectories = new List<string>();
+
+        /// <summary>
+        /// Load the assembly from the specified path.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="args">The arguments of the event.</param>
+        /// <returns>The loaded assembly.</returns>
+        private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            try
+            {
+                // Get the name of the requested assembly.
+                const string extentionType = ".dll";
+                var assemblyName = new AssemblyName(args.Name).Name;
+
+                foreach (var directory in ListOfDirectories)
+                {
+                    // Combine the folder path with the assembly name and ".dll" extension.
+                    var assemblyPath = Path.Combine(directory, assemblyName + extentionType);
+
+                    if (File.Exists(assemblyPath))
+                    {
+                        // Load the assembly from the specified path.
+                        return Assembly.LoadFrom(assemblyPath);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // This exception will be thrown if the assembly is not found in the external DLLs folder.
+            }
+
+            // Return null if the assembly is not found in the external DLLs folder.
+            return null;
+        }
+
+        #endregion
     }
 }

--- a/Sage50c.API.Sample/Sage50c.API.Sample/Sage50c.API.Sample.csproj
+++ b/Sage50c.API.Sample/Sage50c.API.Sample/Sage50c.API.Sample.csproj
@@ -92,124 +92,154 @@
     <Reference Include="ADODB, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <SpecificVersion>False</SpecificVersion>
       <EmbedInteropTypes>False</EmbedInteropTypes>
-      <HintPath>..\..\Interops\ADODB.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\ADODB.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="ADODB27">
-      <HintPath>..\..\Interops\ADODB27.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\ADODB27.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DAO">
-      <HintPath>..\..\Interops\DAO.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\DAO.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="GesAPIInterfaces22">
-      <HintPath>..\..\Interops\GesAPIInterfaces22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\GesAPIInterfaces22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Interop.CertEnroll">
-      <HintPath>..\..\Interops\Interop.CertEnroll.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\Interop.CertEnroll.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="MSScriptControl">
-      <HintPath>..\..\Interops\MSScriptControl.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\MSScriptControl.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="MSXML2">
-      <HintPath>..\..\Interops\MSXML2.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\MSXML2.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cAPI22">
-      <HintPath>..\..\Interops\S50cAPI22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cAPI22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cBL22">
-      <HintPath>..\..\Interops\S50cBL22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cBL22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cBO22">
-      <HintPath>..\..\Interops\S50cBO22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cBO22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cCore22">
-      <HintPath>..\..\Interops\S50cCore22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cCore22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cData22">
-      <HintPath>..\..\Interops\S50cData22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cData22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cDL22">
-      <HintPath>..\..\Interops\S50cDL22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cDL22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cDP22">
-      <HintPath>..\..\Interops\S50cDP22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cDP22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cLocalize22">
-      <HintPath>..\..\Interops\S50cLocalize22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cLocalize22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cPrint22">
-      <HintPath>..\..\Interops\S50cPrint22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cPrint22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cQS22">
-      <HintPath>..\..\Interops\S50cQS22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cQS22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cRV22">
-      <HintPath>..\..\Interops\S50cRV22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cRV22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cSAFTX22">
-      <HintPath>..\..\Interops\S50cSAFTX22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cSAFTX22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cSC22">
-      <HintPath>..\..\Interops\S50cSC22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cSC22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cSys22">
-      <HintPath>..\..\Interops\S50cSys22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cSys22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cUIBase22">
-      <HintPath>..\..\Interops\S50cUIBase22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cUIBase22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cUpdate22">
-      <HintPath>..\..\Interops\S50cUpdate22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cUpdate22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="S50cUtil22">
-      <HintPath>..\..\Interops\S50cUtil22.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\S50cUtil22.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="SageCEMV15">
-      <HintPath>..\..\Interops\SageCEMV15.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\SageCEMV15.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="SageCoreComm10">
-      <HintPath>..\..\Interops\SageCoreComm10.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\SageCoreComm10.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="SageCoreLicenses30">
-      <HintPath>..\..\Interops\SageCoreLicenses30.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\SageCoreLicenses30.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="SageCoreSaft60">
-      <HintPath>..\..\Interops\SageCoreSaft60.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\SageCoreSaft60.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="SageCoreUtil10">
-      <HintPath>..\..\Interops\SageCoreUtil10.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\SageCoreUtil10.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Scripting">
-      <HintPath>..\..\Interops\Scripting.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\Scripting.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -222,28 +252,34 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="VBA">
-      <HintPath>..\..\Interops\VBA.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\VBA.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="VBRUN">
-      <HintPath>..\..\Interops\VBRUN.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\VBRUN.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="XceedZipLib">
-      <HintPath>..\..\Interops\XceedZipLib.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\XceedZipLib.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="XtremeDockingPane">
-      <HintPath>..\..\Interops\XtremeDockingPane.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\XtremeDockingPane.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="XtremeSuiteControls">
-      <HintPath>..\..\Interops\XtremeSuiteControls.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\XtremeSuiteControls.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
     <Reference Include="XtremeTaskPanel">
-      <HintPath>..\..\Interops\XtremeTaskPanel.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Common Files\sage\2070\50c2022\Interops\XtremeTaskPanel.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Load Sage interops directly from instalations instead of working with local files