### PR TITLE
Add user confirmation before clearing transaction UI

### DIFF
--- a/Sage50c.API.Sample/Sage50c.API.Sample/fAPI.cs
+++ b/Sage50c.API.Sample/Sage50c.API.Sample/fAPI.cs
@@ -1493,7 +1493,9 @@ namespace Sage50c.API.Sample {
                 transactionID = _itemTransactionController.Transaction.TransactionID;
             }
             TransactionPrintWithConfig(_itemTransactionController.Transaction.TransSerial, _itemTransactionController.Transaction.TransDocument, _itemTransactionController.Transaction.TransDocNumber);
-            TransactionClearUI();
+
+            if (APIEngine.CoreGlobals.MsgBoxFrontOffice("Clean UI?", VBA.VbMsgBoxStyle.vbYesNo, Application.ProductName) == VBA.VbMsgBoxResult.vbYes)
+                TransactionClearUI();
             return transactionID;
         }
 


### PR DESCRIPTION
The `TransactionClearUI()` method is now executed conditionally based on user input. A message box (`MsgBoxFrontOffice`) prompts the user with "Clean UI?" and Yes/No options. Selecting "Yes" executes the method, while "No" skips it. This change prevents accidental clearing of the transaction interface.